### PR TITLE
Add release ID as output for chaining to github.release.upload

### DIFF
--- a/.opspec/build/Dockerfile
+++ b/.opspec/build/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine:3.6
 
 RUN apk -U add curl
+RUN apk -U add jq

--- a/.opspec/provision-image/Dockerfile
+++ b/.opspec/provision-image/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine:3.6
 
 RUN apk -U add curl
+RUN apk -U add jq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes will be documented in this file in accordance with
 
 ## \[Unreleased]
 
+## \[1.2.0] - 2020-11-05
+
+- added `id` output
+
 ## \[1.1.0] - 2018-03-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ the op uses [![opspec 0.1.5](https://img.shields.io/badge/opspec-0.1.5-brightgre
 ## Install
 
 ```shell
-opctl op install github.com/opspec-pkgs/github.release.create#1.1.0
+opctl op install github.com/opspec-pkgs/github.release.create#1.2.0-alpha
 ```
 
 ## Run
 
 ```
-opctl run github.com/opspec-pkgs/github.release.create#1.1.0
+opctl run github.com/opspec-pkgs/github.release.create#1.2.0-alpha
 ```
 
 ## Compose
 
 ```yaml
 op:
-  ref: github.com/opspec-pkgs/github.release.create#1.1.0
+  ref: github.com/opspec-pkgs/github.release.create#1.2.0-alpha
   inputs:
     commitish:
     loginPassword:
@@ -41,6 +41,8 @@ op:
     isDraft:
     isPrerelease:
     name:
+  outputs:
+    id:
 ```
 
 # Support

--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ the op uses [![opspec 0.1.5](https://img.shields.io/badge/opspec-0.1.5-brightgre
 ## Install
 
 ```shell
-opctl op install github.com/opspec-pkgs/github.release.create#1.2.0-alpha
+opctl op install github.com/opspec-pkgs/github.release.create#1.2.0-alpha1
 ```
 
 ## Run
 
 ```
-opctl run github.com/opspec-pkgs/github.release.create#1.2.0-alpha
+opctl run github.com/opspec-pkgs/github.release.create#1.2.0-alpha1
 ```
 
 ## Compose
 
 ```yaml
 op:
-  ref: github.com/opspec-pkgs/github.release.create#1.2.0-alpha
+  ref: github.com/opspec-pkgs/github.release.create#1.2.0-alpha1
   inputs:
     commitish:
     loginPassword:

--- a/cmd.sh
+++ b/cmd.sh
@@ -15,8 +15,7 @@ EOF
 
 statusCode=$(curl \
     --silent \
-    --output \
-    /dev/stderr \
+    --output response \
     --write-out "%{http_code}" \
     --user "${loginUsername}:${loginPassword}" \
     -X POST "https://api.github.com/repos/${owner}/${repo}/releases" \
@@ -25,3 +24,6 @@ statusCode=$(curl \
 if test "$statusCode" -ne 201; then
 exit 1
 fi
+
+# Record the release ID
+cat response | jq -r .id | tr -d '\n' > /id

--- a/op.yml
+++ b/op.yml
@@ -53,7 +53,7 @@ outputs:
 version: 1.2.0-alpha1
 run:
   container:
-    image: { ref: 'opspecpkgs/github.release.create:1.2.0-alpha' }
+    image: { ref: 'opspecpkgs/github.release.create:1.2.0-alpha1' }
     cmd: [ /cmd.sh ]
     envVars:
       owner:

--- a/op.yml
+++ b/op.yml
@@ -50,10 +50,10 @@ outputs:
   id:
     number:
       description: ID of the created release, can be used as input for other github.release ops
-version: 1.2.0-alpha1
+version: 1.2.0
 run:
   container:
-    image: { ref: 'opspecpkgs/github.release.create:1.2.0-alpha1' }
+    image: { ref: 'opspecpkgs/github.release.create:1.2.0' }
     cmd: [ /cmd.sh ]
     envVars:
       owner:

--- a/op.yml
+++ b/op.yml
@@ -46,10 +46,14 @@ inputs:
       constraints: { enum: ['true', 'false'] }
       description: if the release is a pre-release
       default: 'false'
-version: 1.1.0
+outputs:
+  id:
+    number:
+      description: ID of the created release, can be used as input for other github.release ops
+version: 1.2.0-alpha1
 run:
   container:
-    image: { ref: 'opspecpkgs/github.release.create:1.1.0' }
+    image: { ref: 'opspecpkgs/github.release.create:1.2.0-alpha' }
     cmd: [ /cmd.sh ]
     envVars:
       owner:
@@ -62,4 +66,6 @@ run:
       description:
       isDraft:
       isPrerelease:
-    files: { /cmd.sh }
+    files:
+      /cmd.sh: $(/cmd.sh)
+      /id: $(id)


### PR DESCRIPTION
This adds the GitHub release ID to outputs of this op, so that it can used as input to [`github.release.upload`](https://github.com/opspec-pkgs/github.release.upload).

I'll bump the version from 1.2.0-alpha1 to 1.2.0 before/after merging when this PR is approved.