### PR TITLE
add e2e-test-op & fix some bugs

### DIFF
--- a/.opspec/e2e-test/op.yml
+++ b/.opspec/e2e-test/op.yml
@@ -1,0 +1,64 @@
+name: e2e-test
+description: tests the op
+inputs:
+  owner:
+    string:
+      constraints: { minLength: 1 }
+      description: the github account owner of the release
+  repo:
+    string:
+      constraints: { minLength: 1 }
+      description: the github repo of the release
+  loginUsername:
+    string:
+      constraints: { minLength: 1 }
+      description: user for logging in to the github api
+  loginPassword:
+    string:
+      constraints: { minLength: 1 }
+      description: password for logging in to the github api
+      isSecret: true
+  tag:
+    string:
+      constraints: { minLength: 1 }
+      description: tag to create and associate w/ the release
+  commitish:
+    string:
+      constraints: { minLength: 1 }
+      description: commitish to associate w/ the release
+  name:
+    string:
+      constraints: { minLength: 1 }
+      description: name of release; defaults to tag
+      default: ' '
+  description:
+    string:
+      constraints: { minLength: 1 }
+      description: description of the release
+      default: ' '
+  isDraft:
+    string:
+      constraints: { enum: ['true', 'false'] }
+      description: if the release is a draft
+      default: 'false'
+  isPrerelease:
+    string:
+      constraints: { enum: ['true', 'false'] }
+      description: if the release is a pre-release
+      default: 'false'
+run:
+  op:
+    ref: ../..
+    inputs:
+      owner:
+      repo:
+      loginUsername:
+      loginPassword:
+      tag:
+      commitish:
+      name:
+      description:
+      isDraft:
+      isPrerelease:
+    outputs:
+      id:

--- a/.opspec/e2e-test/op.yml
+++ b/.opspec/e2e-test/op.yml
@@ -48,7 +48,7 @@ inputs:
       default: 'false'
 run:
   op:
-    ref: ../..
+    ref: $(../..)
     inputs:
       owner:
       repo:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes will be documented in this file in accordance with
 
 ## \[Unreleased]
 
-## [2.0.0] - 2024-05-28
+## \[2.0.1] - 2024-08-21
+
+### Fixed
+- if listing releases fails, fail the op immediately instead of trying to continue
+- Correctly escape variables used in the `jq` command to find a release by name so that the command doesn't break when special characters in a name
+
+## \[2.0.0] - 2024-05-28
 
 ### Added
 - When creating a release fails, increase the amount of output so that errors are more transparent to consumers of the op

--- a/README.md
+++ b/README.md
@@ -12,20 +12,20 @@ creates a github release
 ## Visualize
 
 ```shell
-opctl ui github.com/opspec-pkgs/github.release.create#2.0.0
+opctl ui github.com/opspec-pkgs/github.release.create#2.0.1
 ```
 
 ## Run
 
 ```
-opctl run github.com/opspec-pkgs/github.release.create#2.0.0
+opctl run github.com/opspec-pkgs/github.release.create#2.0.1
 ```
 
 ## Compose
 
 ```yaml
 op:
-  ref: github.com/opspec-pkgs/github.release.create#2.0.0
+  ref: github.com/opspec-pkgs/github.release.create#2.0.1
   inputs:
     commitish:  # 👈 required; provide a value
     loginPassword:  # 👈 required; provide a value

--- a/cmd.sh
+++ b/cmd.sh
@@ -19,8 +19,6 @@ fi
 
 results=$(cat response | jq ".[] | select(.name == \"$name\") | [.id]")
 
-echo "Results: $results"
-
 # If more than one release with the same name exists, something has gone wrong.
 # This op isn't responsible for figuring out which release to use, so we fail and
 # give the user some information about how to fix the issue.

--- a/cmd.sh
+++ b/cmd.sh
@@ -6,13 +6,18 @@ set -e
 # using JQ to see if a release with the provided name already exists.
 listReleasesStatusCode=$(curl \
   --silent \
-  --user "${loginUsername}:${loginPassword}" \
+  -H "Authorization: Bearer ${loginPassword}" \
   -X GET "https://api.github.com/repos/${owner}/${repo}/releases?per_page=30" \
   --output response \
   --write-out "%{http_code}"
 )
 
-results=$(cat response | jq '.[] | select(.name == "'$name'") | [.id]')
+if test "$listReleasesStatusCode" -ne 200; then
+  echo "Failed to list releases with status code $listReleasesStatusCode"
+  exit 1
+fi
+
+results=$(cat response | jq ".[] | select(.name == \"$name\") | [.id]")
 
 echo "Results: $results"
 
@@ -33,11 +38,6 @@ if [ -n "$results" ]; then
   exit 0
 else
   echo "No release with name $name exists"
-fi
-
-if test "$listReleasesStatusCode" -ne 200; then
-  echo "Failed to list releases with status code $listReleasesStatusCode"
-  exit 1
 fi
 
 cat > body <<EOF

--- a/op.yml
+++ b/op.yml
@@ -50,7 +50,7 @@ outputs:
   id:
     number:
       description: ID of the created release, can be used as input for other github.release ops
-version: 2.0.0
+version: 2.0.1
 run:
   container:
     image: { ref: 'opspecpkgs/github.release.create:1.2.0' }


### PR DESCRIPTION
# Overview
A user reported a bug with v2.0.0 of this op where their release name contained a `[` and it caused a `jq` compile error. This PR fixes that bug and also fails earlier if listing releases didn't return a 200 response code.

## Testing
I commented out the bit of the op that creates a release and ran the e2e-test op with the release that cause the issue. With the code in this PR that e2e-test run was successful